### PR TITLE
Page title cause issues with testing suites

### DIFF
--- a/views/pug/profile.pug
+++ b/views/pug/profile.pug
@@ -8,7 +8,7 @@ html
     meta(name='viewport', content='width=device-width, initial-scale=1')
     link(rel='stylesheet', href='/public/style.css')
   body
-    h1.border.center FCC Advanced Node and Express
+    h1.border.center Profile Page
     //add your code below, make sure its indented at this level
     
         


### PR DESCRIPTION
Tests fail constantly and seem to be helped if the title is changed
https://www.freecodecamp.org/learn/information-security-and-quality-assurance/advanced-node-and-express/how-to-use-passport-strategies

It seems based on recommendations from others as well that this name of this page needs to be Profile Page in order to pass tests:
https://www.freecodecamp.org/forum/t/advanced-node-and-express-registration-of-new-users/208071/7