### PR TITLE
Fixed 'Create New Middleware' Challenge

### DIFF
--- a/views/pug/index.pug
+++ b/views/pug/index.pug
@@ -8,6 +8,7 @@ html
     link(rel='stylesheet', href='/public/style.css')
   body
     h1.border.center FCC Advanced Node and Express
+    h2.center Home page
     h2.center#pug-success-message
     | Looks like this page is being rendered from Pug into HTML!
     | #{title}


### PR DESCRIPTION
The second test of the 'Create New Middleware' tests the redirection to the home page by checking that the text 'Home page' is present on the resulting page.
Thus, the test cannot pass without this tag.